### PR TITLE
Update deprecated locale on weeklyformattedprice extension

### DIFF
--- a/Sources/GMPremiumManager/Extensions/AdaptyPaywallProduct+Extension.swift
+++ b/Sources/GMPremiumManager/Extensions/AdaptyPaywallProduct+Extension.swift
@@ -24,17 +24,18 @@ extension AdaptyPaywallProduct {
 public extension AdaptyPaywallProduct {
     func weeklyFormattedPrice() -> String? {
         guard let subscriptionPeriodUnit = self.subscriptionPeriod?.unit else { return nil }
+        let locale = self.sk2Product?.priceFormatStyle.locale
 
         switch subscriptionPeriodUnit {
         case .month:
             let price = (self.price as NSNumber).doubleValue / 4
-            return (price as NSNumber).getPrice(for: self.sk1Product?.priceLocale)
+            return (price as NSNumber).getPrice(for: locale)
         case .year:
-            let price = (self.price as NSNumber).doubleValue / 52
-            return (price as NSNumber).getPrice(for: self.sk1Product?.priceLocale)
+            let numberOfWeeksInAYear = Calendar.current.maximumRange(of: .weekOfYear)?.upperBound ?? 52
+            let price = (self.price as NSNumber).doubleValue / Double(numberOfWeeksInAYear)
+            return (price as NSNumber).getPrice(for: locale)
         default: break
         }
-
-        return (price as NSNumber).getPrice(for: self.sk1Product?.priceLocale)
+        return (price as NSNumber).getPrice(for: locale)
     }
 }


### PR DESCRIPTION
price locale is deprecated on iOS 18, returning nil and getting the locale's of device to format the price
Which can result in different currency symbols since the locale of device and from product can vary
This PR update to get the locale from sk2 product 

| Before  | After |
| ------------- | ------------- |
|  <img width="495" alt="Captura de Tela 2025-06-03 às 10 05 03 AM" src="https://github.com/user-attachments/assets/dd3ab189-f555-477b-9e4c-2adf810bea0c" />  |  <img width="495" alt="Captura de Tela 2025-06-03 às 10 19 09 AM" src="https://github.com/user-attachments/assets/dced17a0-e72f-4eb3-b44c-8661c71ebfe8" /> |